### PR TITLE
Problem: incorrect link to pull requests

### DIFF
--- a/42/README.md
+++ b/42/README.md
@@ -6,7 +6,7 @@ status: stable
 editor: Pieter Hintjens <ph@imatix.com>
 ---
 
-The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](http://help.github.com/send-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 2 of the C4 specification and deprecates RFC 22.
+The Collective Code Construction Contract (C4) is an evolution of the github.com [Fork + Pull Model](https://help.github.com/articles/about-pull-requests/), aimed at providing an optimal collaboration model for free software projects. This is revision 2 of the C4 specification and deprecates RFC 22.
 
 ## License
 


### PR DESCRIPTION
Solution: use a working link for pull requests. Github's help seems to have changed - I am not sure what the original link was supposed to be, but this is the best i could find.
